### PR TITLE
Add basic domain entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # BilimApp
+
+This project contains a Spring Boot application. The initial domain model includes several learning-related entities used by the Telegram mini app.
+
+## Entities
+
+- **Subject** – top level course or discipline.
+- **SubjectSubgroup** – subsection within a subject.
+- **Question** – belongs to a subgroup and stores question text.
+- **Answer** – possible answer related to a question.
+- **AppUser** – Telegram mini app user information.

--- a/src/main/java/kg/bilim_app/model/Answer.java
+++ b/src/main/java/kg/bilim_app/model/Answer.java
@@ -1,0 +1,23 @@
+package kg.bilim_app.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@Entity
+public class Answer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "text")
+    private String text;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private Question question;
+}

--- a/src/main/java/kg/bilim_app/model/AppUser.java
+++ b/src/main/java/kg/bilim_app/model/AppUser.java
@@ -1,0 +1,16 @@
+package kg.bilim_app.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+public class AppUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long telegramId;
+    private String firstName;
+    private String lastName;
+}

--- a/src/main/java/kg/bilim_app/model/Question.java
+++ b/src/main/java/kg/bilim_app/model/Question.java
@@ -1,0 +1,30 @@
+package kg.bilim_app.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@Entity
+public class Question {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "text")
+    private String text;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subgroup_id")
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private SubjectSubgroup subgroup;
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private List<Answer> answers;
+}

--- a/src/main/java/kg/bilim_app/model/Subject.java
+++ b/src/main/java/kg/bilim_app/model/Subject.java
@@ -1,0 +1,23 @@
+package kg.bilim_app.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@Entity
+public class Subject {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "subject", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private List<SubjectSubgroup> subgroups;
+}

--- a/src/main/java/kg/bilim_app/model/SubjectSubgroup.java
+++ b/src/main/java/kg/bilim_app/model/SubjectSubgroup.java
@@ -1,0 +1,29 @@
+package kg.bilim_app.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@Entity
+public class SubjectSubgroup {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subject_id")
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private Subject subject;
+
+    @OneToMany(mappedBy = "subgroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private List<Question> questions;
+}

--- a/src/main/java/kg/bilim_app/repository/AnswerRepository.java
+++ b/src/main/java/kg/bilim_app/repository/AnswerRepository.java
@@ -1,0 +1,7 @@
+package kg.bilim_app.repository;
+
+import kg.bilim_app.model.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+}

--- a/src/main/java/kg/bilim_app/repository/AppUserRepository.java
+++ b/src/main/java/kg/bilim_app/repository/AppUserRepository.java
@@ -1,0 +1,7 @@
+package kg.bilim_app.repository;
+
+import kg.bilim_app.model.AppUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppUserRepository extends JpaRepository<AppUser, Long> {
+}

--- a/src/main/java/kg/bilim_app/repository/QuestionRepository.java
+++ b/src/main/java/kg/bilim_app/repository/QuestionRepository.java
@@ -1,0 +1,7 @@
+package kg.bilim_app.repository;
+
+import kg.bilim_app.model.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/kg/bilim_app/repository/SubjectRepository.java
+++ b/src/main/java/kg/bilim_app/repository/SubjectRepository.java
@@ -1,0 +1,7 @@
+package kg.bilim_app.repository;
+
+import kg.bilim_app.model.Subject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubjectRepository extends JpaRepository<Subject, Long> {
+}

--- a/src/main/java/kg/bilim_app/repository/SubjectSubgroupRepository.java
+++ b/src/main/java/kg/bilim_app/repository/SubjectSubgroupRepository.java
@@ -1,0 +1,7 @@
+package kg.bilim_app.repository;
+
+import kg.bilim_app.model.SubjectSubgroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubjectSubgroupRepository extends JpaRepository<SubjectSubgroup, Long> {
+}


### PR DESCRIPTION
## Summary
- fix README
- add JPA entities for subjects, subgroups, questions, answers and users
- add Spring Data repositories for each entity

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684baab5896c8325b8755dbae3b94d9b