### PR TITLE
Add location domain and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ This project contains a Spring Boot application. The initial domain model includ
 - **Question** – belongs to a subgroup and stores question text.
 - **Answer** – possible answer related to a question.
 - **AppUser** – Telegram mini app user information.
+- **Region** – administrative area with Kyrgyz and Russian names.
+- **City** – belongs to a region.
+- **School** – belongs to a city and contains users.

--- a/admin-api/src/main/java/kg/bilim_app/admin_api/AdminApiApplication.java
+++ b/admin-api/src/main/java/kg/bilim_app/admin_api/AdminApiApplication.java
@@ -3,8 +3,10 @@ package kg.bilim_app.admin_api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.cache.annotation.EnableCaching;
 
 @EnableJpaAuditing
+@EnableCaching
 @SpringBootApplication(scanBasePackages = "kg.bilim_app")
 public class AdminApiApplication {
     public static void main(String[] args) {

--- a/admin-api/src/main/java/kg/bilim_app/admin_api/controller/LocationAdminController.java
+++ b/admin-api/src/main/java/kg/bilim_app/admin_api/controller/LocationAdminController.java
@@ -1,0 +1,39 @@
+package kg.bilim_app.admin_api.controller;
+
+import kg.bilim_app.admin_api.dto.NewCityRequest;
+import kg.bilim_app.admin_api.dto.NewRegionRequest;
+import kg.bilim_app.admin_api.dto.NewSchoolRequest;
+import kg.bilim_app.admin_api.service.location.LocationAdminService;
+import kg.bilim_app.ort.entities.City;
+import kg.bilim_app.ort.entities.Region;
+import kg.bilim_app.ort.entities.School;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/location")
+@RequiredArgsConstructor
+public class LocationAdminController {
+
+    private final LocationAdminService service;
+
+    @PostMapping("/regions")
+    public Region createRegion(@RequestBody NewRegionRequest request) {
+        return service.createRegion(request);
+    }
+
+    @PostMapping("/cities")
+    public City createCity(@RequestBody NewCityRequest request) {
+        return service.createCity(request);
+    }
+
+    @PostMapping("/schools")
+    public School createSchool(@RequestBody NewSchoolRequest request) {
+        return service.createSchool(request);
+    }
+
+    @PostMapping("/cache/evict")
+    public void evictCache() {
+        service.evictCache();
+    }
+}

--- a/admin-api/src/main/java/kg/bilim_app/admin_api/dto/NewCityRequest.java
+++ b/admin-api/src/main/java/kg/bilim_app/admin_api/dto/NewCityRequest.java
@@ -1,0 +1,10 @@
+package kg.bilim_app.admin_api.dto;
+
+import lombok.Data;
+
+@Data
+public class NewCityRequest {
+    private String nameRu;
+    private String nameKy;
+    private Long regionId;
+}

--- a/admin-api/src/main/java/kg/bilim_app/admin_api/dto/NewRegionRequest.java
+++ b/admin-api/src/main/java/kg/bilim_app/admin_api/dto/NewRegionRequest.java
@@ -1,0 +1,9 @@
+package kg.bilim_app.admin_api.dto;
+
+import lombok.Data;
+
+@Data
+public class NewRegionRequest {
+    private String nameRu;
+    private String nameKy;
+}

--- a/admin-api/src/main/java/kg/bilim_app/admin_api/dto/NewSchoolRequest.java
+++ b/admin-api/src/main/java/kg/bilim_app/admin_api/dto/NewSchoolRequest.java
@@ -1,0 +1,10 @@
+package kg.bilim_app.admin_api.dto;
+
+import lombok.Data;
+
+@Data
+public class NewSchoolRequest {
+    private String nameRu;
+    private String nameKy;
+    private Long cityId;
+}

--- a/admin-api/src/main/java/kg/bilim_app/admin_api/service/location/LocationAdminService.java
+++ b/admin-api/src/main/java/kg/bilim_app/admin_api/service/location/LocationAdminService.java
@@ -1,0 +1,60 @@
+package kg.bilim_app.admin_api.service.location;
+
+import kg.bilim_app.admin_api.dto.NewCityRequest;
+import kg.bilim_app.admin_api.dto.NewRegionRequest;
+import kg.bilim_app.admin_api.dto.NewSchoolRequest;
+import kg.bilim_app.ort.entities.City;
+import kg.bilim_app.ort.entities.Region;
+import kg.bilim_app.ort.entities.School;
+import kg.bilim_app.ort.repositories.CityRepository;
+import kg.bilim_app.ort.repositories.RegionRepository;
+import kg.bilim_app.ort.repositories.SchoolRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class LocationAdminService {
+
+    private final RegionRepository regionRepository;
+    private final CityRepository cityRepository;
+    private final SchoolRepository schoolRepository;
+
+    @CacheEvict(value = {"regions", "cities", "schools"}, allEntries = true)
+    public Region createRegion(NewRegionRequest request) {
+        Region region = new Region();
+        region.setNameRu(request.getNameRu());
+        region.setNameKy(request.getNameKy());
+        return regionRepository.save(region);
+    }
+
+    @CacheEvict(value = {"regions", "cities", "schools"}, allEntries = true)
+    public City createCity(NewCityRequest request) {
+        Region region = regionRepository.findById(request.getRegionId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Region not found"));
+        City city = new City();
+        city.setNameRu(request.getNameRu());
+        city.setNameKy(request.getNameKy());
+        city.setRegion(region);
+        return cityRepository.save(city);
+    }
+
+    @CacheEvict(value = {"regions", "cities", "schools"}, allEntries = true)
+    public School createSchool(NewSchoolRequest request) {
+        City city = cityRepository.findById(request.getCityId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "City not found"));
+        School school = new School();
+        school.setNameRu(request.getNameRu());
+        school.setNameKy(request.getNameKy());
+        school.setCity(city);
+        return schoolRepository.save(school);
+    }
+
+    @CacheEvict(value = {"regions", "cities", "schools"}, allEntries = true)
+    public void evictCache() {
+        // cache eviction handled by annotation
+    }
+}

--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/MobileApiApplication.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/MobileApiApplication.java
@@ -3,8 +3,10 @@ package kg.bilim_app.mobile_api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.cache.annotation.EnableCaching;
 
 @EnableJpaAuditing
+@EnableCaching
 @SpringBootApplication(scanBasePackages = "kg.bilim_app")
 public class MobileApiApplication {
 

--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/controller/LocationController.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/controller/LocationController.java
@@ -1,0 +1,36 @@
+package kg.bilim_app.mobile_api.controller;
+
+import kg.bilim_app.mobile_api.service.LocationService;
+import kg.bilim_app.ort.entities.City;
+import kg.bilim_app.ort.entities.Region;
+import kg.bilim_app.ort.entities.School;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/location")
+@RequiredArgsConstructor
+public class LocationController {
+
+    private final LocationService service;
+
+    @GetMapping("/regions")
+    public List<Region> getRegions() {
+        return service.getRegions();
+    }
+
+    @GetMapping("/cities/{regionId}")
+    public List<City> getCities(@PathVariable Long regionId) {
+        return service.getCities(regionId);
+    }
+
+    @GetMapping("/schools/{cityId}")
+    public List<School> getSchools(@PathVariable Long cityId) {
+        return service.getSchools(cityId);
+    }
+}

--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/LocationService.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/LocationService.java
@@ -1,0 +1,37 @@
+package kg.bilim_app.mobile_api.service;
+
+import kg.bilim_app.ort.entities.City;
+import kg.bilim_app.ort.entities.Region;
+import kg.bilim_app.ort.entities.School;
+import kg.bilim_app.ort.repositories.CityRepository;
+import kg.bilim_app.ort.repositories.RegionRepository;
+import kg.bilim_app.ort.repositories.SchoolRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+    private final RegionRepository regionRepository;
+    private final CityRepository cityRepository;
+    private final SchoolRepository schoolRepository;
+
+    @Cacheable("regions")
+    public List<Region> getRegions() {
+        return regionRepository.findAll();
+    }
+
+    @Cacheable(value = "cities", key = "#regionId")
+    public List<City> getCities(Long regionId) {
+        return cityRepository.findByRegionId(regionId);
+    }
+
+    @Cacheable(value = "schools", key = "#cityId")
+    public List<School> getSchools(Long cityId) {
+        return schoolRepository.findByCityId(cityId);
+    }
+}

--- a/ort/src/main/java/kg/bilim_app/ort/entities/AppUser.java
+++ b/ort/src/main/java/kg/bilim_app/ort/entities/AppUser.java
@@ -6,6 +6,7 @@ import kg.bilim_app.common.models.BaseEntity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.hibernate.annotations.Nationalized;
+import lombok.ToString;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -22,4 +23,10 @@ public class AppUser extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Language language;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id")
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private School school;
 }

--- a/ort/src/main/java/kg/bilim_app/ort/entities/City.java
+++ b/ort/src/main/java/kg/bilim_app/ort/entities/City.java
@@ -1,0 +1,40 @@
+package kg.bilim_app.ort.entities;
+
+import jakarta.persistence.*;
+import kg.bilim_app.common.models.BaseEntity;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.hibernate.annotations.Nationalized;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(indexes = {
+        @Index(columnList = "region_id"),
+        @Index(columnList = "name_ru"),
+        @Index(columnList = "name_ky")
+})
+public class City extends BaseEntity {
+
+    @Nationalized
+    @Column(name = "name_ru")
+    private String nameRu;
+
+    @Nationalized
+    @Column(name = "name_ky")
+    private String nameKy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private Region region;
+
+    @OneToMany(mappedBy = "city", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private List<School> schools;
+}

--- a/ort/src/main/java/kg/bilim_app/ort/entities/Region.java
+++ b/ort/src/main/java/kg/bilim_app/ort/entities/Region.java
@@ -1,0 +1,33 @@
+package kg.bilim_app.ort.entities;
+
+import jakarta.persistence.*;
+import kg.bilim_app.common.models.BaseEntity;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.hibernate.annotations.Nationalized;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(indexes = {
+        @Index(columnList = "name_ru"),
+        @Index(columnList = "name_ky")
+})
+public class Region extends BaseEntity {
+
+    @Nationalized
+    @Column(name = "name_ru")
+    private String nameRu;
+
+    @Nationalized
+    @Column(name = "name_ky")
+    private String nameKy;
+
+    @OneToMany(mappedBy = "region", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private List<City> cities;
+}

--- a/ort/src/main/java/kg/bilim_app/ort/entities/School.java
+++ b/ort/src/main/java/kg/bilim_app/ort/entities/School.java
@@ -1,0 +1,40 @@
+package kg.bilim_app.ort.entities;
+
+import jakarta.persistence.*;
+import kg.bilim_app.common.models.BaseEntity;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.hibernate.annotations.Nationalized;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(indexes = {
+        @Index(columnList = "city_id"),
+        @Index(columnList = "name_ru"),
+        @Index(columnList = "name_ky")
+})
+public class School extends BaseEntity {
+
+    @Nationalized
+    @Column(name = "name_ru")
+    private String nameRu;
+
+    @Nationalized
+    @Column(name = "name_ky")
+    private String nameKy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "city_id")
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private City city;
+
+    @OneToMany(mappedBy = "school")
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private List<AppUser> users;
+}

--- a/ort/src/main/java/kg/bilim_app/ort/repositories/CityRepository.java
+++ b/ort/src/main/java/kg/bilim_app/ort/repositories/CityRepository.java
@@ -1,0 +1,10 @@
+package kg.bilim_app.ort.repositories;
+
+import kg.bilim_app.ort.entities.City;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CityRepository extends JpaRepository<City, Long> {
+    List<City> findByRegionId(Long regionId);
+}

--- a/ort/src/main/java/kg/bilim_app/ort/repositories/RegionRepository.java
+++ b/ort/src/main/java/kg/bilim_app/ort/repositories/RegionRepository.java
@@ -1,0 +1,7 @@
+package kg.bilim_app.ort.repositories;
+
+import kg.bilim_app.ort.entities.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+}

--- a/ort/src/main/java/kg/bilim_app/ort/repositories/SchoolRepository.java
+++ b/ort/src/main/java/kg/bilim_app/ort/repositories/SchoolRepository.java
@@ -1,0 +1,10 @@
+package kg.bilim_app.ort.repositories;
+
+import kg.bilim_app.ort.entities.School;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SchoolRepository extends JpaRepository<School, Long> {
+    List<School> findByCityId(Long cityId);
+}


### PR DESCRIPTION
## Summary
- add Region, City, and School entities with indexes
- link AppUser to School
- add repositories and services for location management
- implement admin endpoints to create regions, cities and schools
- implement mobile endpoints to retrieve location data
- enable caching in both applications
- update README

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb8b3b9a083259b3398554277c0a4