### PR TITLE
Add mobile user registration API

### DIFF
--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/controller/LocationController.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/controller/LocationController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
@@ -19,16 +20,19 @@ public class LocationController {
 
     private final LocationService service;
 
+    @Operation(summary = "Get list of regions")
     @GetMapping("/regions")
     public List<Region> getRegions() {
         return service.getRegions();
     }
 
+    @Operation(summary = "Get cities by region id")
     @GetMapping("/cities/{regionId}")
     public List<City> getCities(@PathVariable Long regionId) {
         return service.getCities(regionId);
     }
 
+    @Operation(summary = "Get schools by city id")
     @GetMapping("/schools/{cityId}")
     public List<School> getSchools(@PathVariable Long cityId) {
         return service.getSchools(cityId);

--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/controller/UserController.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/controller/UserController.java
@@ -1,0 +1,34 @@
+package kg.bilim_app.mobile_api.controller;
+
+import kg.bilim_app.mobile_api.dto.RegisterUserRequest;
+import kg.bilim_app.mobile_api.service.UserService;
+import kg.bilim_app.ort.entities.AppUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService service;
+
+    @Operation(summary = "Register new user")
+    @PostMapping("/register")
+    public AppUser register(@RequestBody RegisterUserRequest request) {
+        return service.registerUser(request);
+    }
+
+    @Operation(summary = "Get user by telegram id")
+    @GetMapping("/{telegramId}")
+    public AppUser getUser(@PathVariable Long telegramId) {
+        return service.getUser(telegramId);
+    }
+
+    @Operation(summary = "Check if user is registered")
+    @GetMapping("/{telegramId}/exists")
+    public boolean isRegistered(@PathVariable Long telegramId) {
+        return service.isRegistered(telegramId);
+    }
+}

--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/dto/RegisterUserRequest.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/dto/RegisterUserRequest.java
@@ -1,0 +1,13 @@
+package kg.bilim_app.mobile_api.dto;
+
+import kg.bilim_app.common.enums.Language;
+import lombok.Data;
+
+@Data
+public class RegisterUserRequest {
+    private Long telegramId;
+    private String firstName;
+    private String lastName;
+    private Long schoolId;
+    private Language language;
+}

--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/UserService.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/UserService.java
@@ -1,0 +1,43 @@
+package kg.bilim_app.mobile_api.service;
+
+import kg.bilim_app.mobile_api.dto.RegisterUserRequest;
+import kg.bilim_app.ort.entities.AppUser;
+import kg.bilim_app.ort.entities.location.School;
+import kg.bilim_app.ort.repositories.AppUserRepository;
+import kg.bilim_app.ort.repositories.SchoolRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final AppUserRepository userRepository;
+    private final SchoolRepository schoolRepository;
+
+    public AppUser registerUser(RegisterUserRequest request) {
+        if (userRepository.findByTelegramId(request.getTelegramId()).isPresent()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "User already exists");
+        }
+        School school = schoolRepository.findById(request.getSchoolId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "School not found"));
+        AppUser user = new AppUser();
+        user.setTelegramId(request.getTelegramId());
+        user.setFirstName(request.getFirstName());
+        user.setLastName(request.getLastName());
+        user.setLanguage(request.getLanguage());
+        user.setSchool(school);
+        return userRepository.save(user);
+    }
+
+    public AppUser getUser(Long telegramId) {
+        return userRepository.findByTelegramId(telegramId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+    }
+
+    public boolean isRegistered(Long telegramId) {
+        return userRepository.findByTelegramId(telegramId).isPresent();
+    }
+}

--- a/ort/src/main/java/kg/bilim_app/ort/repositories/AppUserRepository.java
+++ b/ort/src/main/java/kg/bilim_app/ort/repositories/AppUserRepository.java
@@ -3,5 +3,8 @@ package kg.bilim_app.ort.repositories;
 import kg.bilim_app.ort.entities.AppUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AppUserRepository extends JpaRepository<AppUser, Long> {
+    Optional<AppUser> findByTelegramId(Long telegramId);
 }


### PR DESCRIPTION
## Summary
- add user repository method to search by telegram ID
- add DTO, service, and controller for user registration
- document APIs with Swagger `@Operation` annotations

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc16670208325b3b3394286f7642f