### PR TITLE
Use central helper for authenticated user

### DIFF
--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/controller/SubjectController.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/controller/SubjectController.java
@@ -1,13 +1,11 @@
 package kg.bilim_app.mobile_api.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import kg.bilim_app.common.enums.Language;
 import kg.bilim_app.mobile_api.response.SubjectResponse;
 import kg.bilim_app.mobile_api.service.SubjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -21,7 +19,7 @@ public class SubjectController {
 
     @Operation(summary = "Get list of subjects with subgroups")
     @GetMapping
-    public List<SubjectResponse> getSubjects(@RequestParam Language language) {
-        return service.getSubjects(language);
+    public List<SubjectResponse> getSubjects() {
+        return service.getSubjects();
     }
 }

--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/security/AuthenticatedUserProvider.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/security/AuthenticatedUserProvider.java
@@ -1,0 +1,25 @@
+package kg.bilim_app.mobile_api.security;
+
+import kg.bilim_app.ort.entities.AppUser;
+import kg.bilim_app.ort.repositories.AppUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticatedUserProvider {
+
+    private final AppUserRepository userRepository;
+
+    public AppUser getAuthenticatedUser() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (!(principal instanceof Long telegramId)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");
+        }
+        return userRepository.findByTelegramId(telegramId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+    }
+}

--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/SubjectService.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/SubjectService.java
@@ -1,10 +1,9 @@
 package kg.bilim_app.mobile_api.service;
 
-import kg.bilim_app.common.enums.Language;
 import kg.bilim_app.mobile_api.response.SubjectResponse;
 
 import java.util.List;
 
 public interface SubjectService {
-    List<SubjectResponse> getSubjects(Language language);
+    List<SubjectResponse> getSubjects();
 }

--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/SubjectServiceImpl.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/SubjectServiceImpl.java
@@ -5,6 +5,8 @@ import kg.bilim_app.mobile_api.response.SubjectResponse;
 import kg.bilim_app.mobile_api.response.SubjectSubgroupResponse;
 import kg.bilim_app.ort.entities.test.Subject;
 import kg.bilim_app.ort.repositories.SubjectRepository;
+import kg.bilim_app.ort.entities.AppUser;
+import kg.bilim_app.mobile_api.security.AuthenticatedUserProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,9 +17,12 @@ import java.util.List;
 public class SubjectServiceImpl implements SubjectService {
 
     private final SubjectRepository subjectRepository;
+    private final AuthenticatedUserProvider userProvider;
 
     @Override
-    public List<SubjectResponse> getSubjects(Language language) {
+    public List<SubjectResponse> getSubjects() {
+        AppUser user = userProvider.getAuthenticatedUser();
+        Language language = user.getLanguage();
         return subjectRepository.findByLanguage(language).stream()
                 .map(this::toResponse)
                 .toList();


### PR DESCRIPTION
## Summary
- centralize retrieving the authenticated user
- use the helper in SubjectService implementation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to repo.maven.apache.org network issue)*

------
https://chatgpt.com/codex/tasks/task_e_684cf88e5614832595c17e87b6f147da