### PR TITLE
Open mobile user registration route

### DIFF
--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/security/SecurityConfig.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/security/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
         http.csrf(csrf -> csrf.disable());
         http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
         http.authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                .requestMatchers("/auth/**", "/users/register", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                 .anyRequest().authenticated());
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();


### PR DESCRIPTION
## Summary
- make `/users/register` accessible without authentication

## Testing
- `mvn -q -pl mobile-api test` *(fails: could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684cfe1d51988325b505e915070f5b07