### PR TITLE
Fix Telegram WebApp initData verification

### DIFF
--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/AuthServiceImpl.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/AuthServiceImpl.java
@@ -69,13 +69,20 @@ public class AuthServiceImpl implements AuthService {
         }
     }
 
-    /** Разбирает строку «key1=val1&key2=val2…» без URL-decode значений */
+    /**
+     * Parses the initData string into raw key–value pairs.
+     * Telegram sends this value URL-encoded, so we need to decode
+     * the whole string once before splitting by '&'. The individual
+     * parameter values should remain encoded to correctly recreate
+     * the {@code data_check_string}.
+     */
     private Map<String, String> parseRaw(String initData) {
+        String decoded = URLDecoder.decode(initData, StandardCharsets.UTF_8);
         Map<String, String> map = new HashMap<>();
-        for (String pair : initData.split("&")) {
-            String[] p = pair.split("=", 2);
-            if (p.length == 2) {
-                map.put(p[0], p[1]);
+        for (String pair : decoded.split("&")) {
+            int idx = pair.indexOf('=');
+            if (idx >= 0) {
+                map.put(pair.substring(0, idx), pair.substring(idx + 1));
             }
         }
         return map;


### PR DESCRIPTION
## Summary
- fix Telegram initData parsing by URL-decoding the whole string before splitting

## Testing
- `mvn -q -pl mobile-api -am test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684dbbc2e6148325a5dbf6a763c63250