### PR TITLE
Add logging filter with encryption

### DIFF
--- a/admin-api/src/main/resources/application.yml
+++ b/admin-api/src/main/resources/application.yml
@@ -9,8 +9,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+  properties:
+    hibernate:
+      dialect: org.hibernate.dialect.PostgreSQLDialect
+logging:
+  secret-key: ChangeMe1234567890
 server:
   port: 8092

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -17,6 +17,14 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
         </dependency>

--- a/common/src/main/java/kg/bilim_app/common/logging/AccessLogSaver.java
+++ b/common/src/main/java/kg/bilim_app/common/logging/AccessLogSaver.java
@@ -1,0 +1,8 @@
+package kg.bilim_app.common.logging;
+
+/**
+ * Optional bean used by {@link RequestResponseLoggingFilter} to persist IP addresses.
+ */
+public interface AccessLogSaver {
+    void save(String ip, String path, String method);
+}

--- a/common/src/main/java/kg/bilim_app/common/logging/AesEncryptor.java
+++ b/common/src/main/java/kg/bilim_app/common/logging/AesEncryptor.java
@@ -1,0 +1,30 @@
+package kg.bilim_app.common.logging;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+
+/**
+ * Simple AES encryptor used for logging secret values.
+ */
+public class AesEncryptor {
+    private final SecretKeySpec keySpec;
+
+    public AesEncryptor(String key) {
+        byte[] keyBytes = Arrays.copyOf(key.getBytes(StandardCharsets.UTF_8), 16);
+        this.keySpec = new SecretKeySpec(keyBytes, "AES");
+    }
+
+    public String encrypt(String input) {
+        try {
+            Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+            byte[] encrypted = cipher.doFinal(input.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (Exception e) {
+            return "";
+        }
+    }
+}

--- a/common/src/main/java/kg/bilim_app/common/logging/RequestResponseLoggingFilter.java
+++ b/common/src/main/java/kg/bilim_app/common/logging/RequestResponseLoggingFilter.java
@@ -1,0 +1,110 @@
+package kg.bilim_app.common.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import kg.bilim_app.common.logging.AesEncryptor;
+import kg.bilim_app.common.logging.AccessLogSaver;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Logs each request and response while encrypting sensitive parameters.
+ */
+@Slf4j
+@Component
+public class RequestResponseLoggingFilter extends OncePerRequestFilter {
+
+    private final AesEncryptor encryptor;
+    private final AccessLogSaver accessLogSaver;
+
+    public RequestResponseLoggingFilter(
+            @Value("${logging.secret-key:ChangeMe1234567890}") String key,
+            ObjectProvider<AccessLogSaver> saverProvider) {
+        this.encryptor = new AesEncryptor(key);
+        this.accessLogSaver = saverProvider.getIfAvailable();
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
+        try {
+            filterChain.doFilter(wrappedRequest, wrappedResponse);
+        } finally {
+            logRequest(wrappedRequest);
+            logResponse(wrappedResponse);
+            wrappedResponse.copyBodyToResponse();
+        }
+    }
+
+    private void logRequest(ContentCachingRequestWrapper request) {
+        String body = new String(request.getContentAsByteArray(), StandardCharsets.UTF_8);
+        body = sanitize(body);
+
+        Map<String, String[]> params = request.getParameterMap();
+        Map<String, String> sanitized = new HashMap<>();
+        params.forEach((k, v) -> sanitized.put(k, encryptIfSecret(k, String.join(",", v))));
+
+        String ip = resolveIp(request);
+        log.info("Request: {} {} ip={} params={} body={}",
+                request.getMethod(), request.getRequestURI(), ip, sanitized, body);
+        if (accessLogSaver != null) {
+            try {
+                accessLogSaver.save(ip, request.getRequestURI(), request.getMethod());
+            } catch (Exception e) {
+                log.debug("Failed to persist access log", e);
+            }
+        }
+    }
+
+    private void logResponse(ContentCachingResponseWrapper response) throws IOException {
+        String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+        body = sanitize(body);
+        log.info("Response: status={} body={}", response.getStatus(), body);
+    }
+
+    private String resolveIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    private String sanitize(String body) {
+        Pattern p = Pattern.compile("\"(token|password|botToken)\"\s*:\s*\"(.*?)\"", Pattern.CASE_INSENSITIVE);
+        Matcher m = p.matcher(body);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            String enc = encryptor.encrypt(m.group(2));
+            m.appendReplacement(sb, m.group(1) + "\":\"" + enc + "\"");
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    private String encryptIfSecret(String name, String value) {
+        String lower = name.toLowerCase();
+        if (lower.contains("token") || lower.contains("password")) {
+            return encryptor.encrypt(value);
+        }
+        return value;
+    }
+}

--- a/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/AuthServiceImpl.java
+++ b/mobile-api/src/main/java/kg/bilim_app/mobile_api/service/AuthServiceImpl.java
@@ -31,7 +31,6 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public String authenticate(String initData) {
-        log.info("initData: {}", initData);
 
         /* 1. разбираем initData один раз URL-decode, но
               значения оставляем закодированными */
@@ -55,9 +54,6 @@ public class AuthServiceImpl implements AuthService {
         String calculated = bytesToHex(
                 hmac(dcs.getBytes(StandardCharsets.UTF_8), secret));
 
-        log.info("Expected hash: {}", expectedHash);
-        log.info("Calculated hash: {}", calculated);
-        log.info("dataCheckString:\n{}", dcs);
 
         if (!calculated.equals(expectedHash)) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid initData");

--- a/mobile-api/src/main/resources/application.yml
+++ b/mobile-api/src/main/resources/application.yml
@@ -19,6 +19,8 @@ telegram:
 jwt:
   secret: change_me
   expiration: 3600
+logging:
+  secret-key: ChangeMe1234567890
 server:
   port: 8090
 

--- a/ort/src/main/java/kg/bilim_app/ort/entities/logging/AccessLog.java
+++ b/ort/src/main/java/kg/bilim_app/ort/entities/logging/AccessLog.java
@@ -1,0 +1,22 @@
+package kg.bilim_app.ort.entities.logging;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Column;
+import kg.bilim_app.common.models.BaseEntity;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "access_logs")
+public class AccessLog extends BaseEntity {
+
+    @Column(name = "ip_address")
+    private String ipAddress;
+
+    private String path;
+
+    private String method;
+}

--- a/ort/src/main/java/kg/bilim_app/ort/logging/JpaAccessLogSaver.java
+++ b/ort/src/main/java/kg/bilim_app/ort/logging/JpaAccessLogSaver.java
@@ -1,0 +1,25 @@
+package kg.bilim_app.ort.logging;
+
+import kg.bilim_app.common.logging.AccessLogSaver;
+import kg.bilim_app.ort.entities.logging.AccessLog;
+import kg.bilim_app.ort.repositories.logging.AccessLogRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JpaAccessLogSaver implements AccessLogSaver {
+
+    private final AccessLogRepository repository;
+
+    public JpaAccessLogSaver(AccessLogRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public void save(String ip, String path, String method) {
+        AccessLog log = new AccessLog();
+        log.setIpAddress(ip);
+        log.setPath(path);
+        log.setMethod(method);
+        repository.save(log);
+    }
+}

--- a/ort/src/main/java/kg/bilim_app/ort/repositories/logging/AccessLogRepository.java
+++ b/ort/src/main/java/kg/bilim_app/ort/repositories/logging/AccessLogRepository.java
@@ -1,0 +1,7 @@
+package kg.bilim_app.ort.repositories.logging;
+
+import kg.bilim_app.ort.entities.logging.AccessLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccessLogRepository extends JpaRepository<AccessLog, Long> {
+}


### PR DESCRIPTION
## Summary
- implement `AccessLogSaver` and store incoming IP addresses in DB
- enhance `RequestResponseLoggingFilter` to log IPs and persist them

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684e5258ed8c8325a7dcb9dd4d2f3704